### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  contents: read
+
 jobs:
   bake:
     runs-on: blg-runner-set


### PR DESCRIPTION
Potential fix for [https://github.com/LarssonOliver/blg/security/code-scanning/1](https://github.com/LarssonOliver/blg/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out code) and DockerHub. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required in the future, they can be added explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
